### PR TITLE
first working python wrapper for integrator

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -1,0 +1,20 @@
+<use   name="root"/>
+<use   name="rootcintex"/>
+<use   name="rootgraphics"/>
+<use   name="roofit"/>
+<use   name="rootminuit"/>
+<use   name="rootminuit2"/>
+<use   name="roottmva"/>
+<use   name="classlib"/>
+<use   name="boost"/>
+<use   name="lhapdf"/>
+<lib   name="openloops"/>
+<lib   name="coli"/>
+<lib   name="openloops_ppHtt_1tL"/>
+<lib   name="openloops_ppttbb_1tL"/>
+<lib   name="pphttxcallme2born"/>
+<lib   name="ppttxbbxcallme2born"/>
+<Flags CXXFLAGS="-fPIC -g -I$(CMSSW_BASE)/src/TTH/MEIntegratorStandalone -I$(INCLUDE_DIR)" GENREFLEX_ARGS="-I$(CMSSW_BASE)/src/TTH/MEIntegratorStandalone"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/interface/Event.h
+++ b/interface/Event.h
@@ -13,8 +13,8 @@ using namespace std;
 namespace Algo {
 
   struct TreeStruct {    
-    size_t n_h;             // num of hypo
-    size_t n_dim;           // total number of dimensions
+    std::size_t n_h;             // num of hypo
+    std::size_t n_dim;           // total number of dimensions
     int    all_time;        // total CPU time (msec)
     int    n_btag;          // n btag
     int    n_jet;           // n jet
@@ -39,8 +39,8 @@ namespace Algo {
       os << "\tn_btag   = " << n_btag << endl;
       os << "\tn_jet    = " << n_jet  << endl;
       os << "\tn_lep    = " << n_lep  << endl;
-      size_t it_p {0};
-      for( size_t i = 0 ; (i < n_h && i < (size_t)HMAX) ; ++i){
+      std::size_t it_p = 0;
+      for( std::size_t i = 0 ; (i < n_h && i < (std::size_t)HMAX) ; ++i){
 	os << "\tHypo "     << i << ": "   << endl;
 	os << "\tstatus["     << i << "] = " << status[i];
 	os << ", strategy[" << i << "] = " << strategy[i];
@@ -63,6 +63,7 @@ namespace Algo {
 
   struct Event {
     Event (TTree*) ;
+    Event();
     ~Event();
     void fillTree () ;
     void printTree() ;

--- a/interface/HypoTester.h
+++ b/interface/HypoTester.h
@@ -5,8 +5,8 @@
 #include "Math/Factory.h"
 #include "Math/Functor.h"
 
-#include "interface/StandardIncludes.h"
-#include "interface/Event.h"
+#include "TTH/MEIntegratorStandalone/interface/StandardIncludes.h"
+#include "TTH/MEIntegratorStandalone/interface/Event.h"
 
 namespace Algo {
 
@@ -29,7 +29,7 @@ namespace Algo {
     void add_object_observables ( const string&, const double& , const char);
      
     // method called by user
-    void test( const map< string,vector<Decay>>& );
+    void test( const map< string,vector<Decay::Decay> >& );
 
     // print objects
     void print(ostream&);
@@ -43,7 +43,7 @@ namespace Algo {
   private:
 
     // Add hypothesis. Called by test()
-    void assume(Decay); 
+    void assume(Decay::Decay); 
 
     // Read the parameters and do permutations. Uses:
     //   - unpack_assumptions()
@@ -76,14 +76,14 @@ namespace Algo {
 
     // check whether a given variable is 
     // in at least one permutation
-    bool is_variable_used( const size_t );
+    bool is_variable_used( const std::size_t );
 
     // print permutation  
-    void print_permutation(const vector<std::pair<FinalState,size_t>>&) const;
+    void print_permutation(const vector<std::pair<FinalState::FinalState,std::size_t> >&) const;
 
     // filter out permutations. Uses:
     //  - print_permutation()
-    bool go_to_next(vector<vector<std::pair<FinalState,size_t>>> &);
+    bool go_to_next(vector<vector<std::pair<FinalState::FinalState,std::size_t> > > &);
 
     // internal method to save global variables
     void save_global_variables();
@@ -97,31 +97,31 @@ namespace Algo {
     vector<Algo::Object> p4_MET;  
 
     // filled by test()
-    vector<Decay> decays;
+    vector<Decay::Decay> decays;
 
     // vector or particles. Filled by unpack_assumptions()
     // it gets permutated by init()
-    vector<pair<FinalState,size_t>> particles;
+    vector<pair<FinalState::FinalState, std::size_t> > particles;
 
     // the actual permutations
     vector<Algo::CombBuilder*> permutations;
 
-    size_t nParam_j;
-    size_t nParam_n;
-    size_t nParam_m;
+    std::size_t nParam_j;
+    std::size_t nParam_n;
+    std::size_t nParam_m;
     int    count_hypo;
     int    count_perm;
-    size_t count_TopHad;
-    size_t count_TopHadLost;
-    size_t count_WHad;
-    size_t count_TopLep;
-    size_t count_Higgs;
-    size_t count_Radiation_u;
-    size_t count_Radiation_d;
-    size_t count_Radiation_c;
-    size_t count_Radiation_b;
-    size_t count_Radiation_g;
-    size_t invisible;
+    std::size_t count_TopHad;
+    std::size_t count_TopHadLost;
+    std::size_t count_WHad;
+    std::size_t count_TopLep;
+    std::size_t count_Higgs;
+    std::size_t count_Radiation_u;
+    std::size_t count_Radiation_d;
+    std::size_t count_Radiation_c;
+    std::size_t count_Radiation_b;
+    std::size_t count_Radiation_g;
+    std::size_t invisible;
     int verbose;
     int error_code;
 

--- a/interface/Integrand.h
+++ b/interface/Integrand.h
@@ -86,9 +86,9 @@ namespace MEM {
 
     double probability(const double*, const vector<int>&) const;
 
-    double t_decay_amplitude(const TLorentzVector&, const TLorentzVector&, const TLorentzVector&) const;
+    double t_Decay_amplitude(const TLorentzVector&, const TLorentzVector&, const TLorentzVector&) const;
 
-    double H_decay_amplitude(const TLorentzVector&, const TLorentzVector&) const;
+    double H_Decay_amplitude(const TLorentzVector&, const TLorentzVector&) const;
 
     double pdf(const double&, const double&, const double&) const;
 

--- a/interface/StandardIncludes.h
+++ b/interface/StandardIncludes.h
@@ -1,7 +1,7 @@
 #ifndef STANDARDINCLUDES_H
 #define STANDARDINCLUDES_H
 
-#include "interface/Utils.h"
+#include "TTH/MEIntegratorStandalone/interface/Utils.h"
 
 using namespace std;
 
@@ -33,20 +33,20 @@ namespace Algo {
     virtual ~DecayBuilder() {};
     virtual double eval( const double* , LV&) = 0; 
     virtual void   print(ostream&) = 0;
-    virtual Decay  get_decay() = 0;
+    virtual Decay::Decay  get_decay() = 0;
   };
      
   class CombBuilder: public DecayBuilder {
   public:
-    CombBuilder(vector<DecayBuilder*>&& = vector<DecayBuilder*>(), int =0);
+    CombBuilder(vector<DecayBuilder*> = vector<DecayBuilder*>(), int =0);
     ~CombBuilder();
     void          add(DecayBuilder*);
     double        eval ( const double* , LV&);
     double        eval ( const double* );
     void          print(ostream&);
-    DecayBuilder* at(const size_t&);
-    size_t        size();
-    Decay         get_decay();
+    DecayBuilder* at(const std::size_t);
+    std::size_t size();
+    Decay::Decay         get_decay();
   private:
     vector<DecayBuilder*> combined;
     int verbose;
@@ -60,11 +60,11 @@ namespace Algo {
     double eval (  const double* , LV& );
     void   fix_vars();
     void   print(ostream&);   
-    Decay  get_decay();
+    Decay::Decay  get_decay();
   private:
     LV p4_invisible;
     TransferFunction* tf_met;
-    Decay  decay;
+    Decay::Decay  decay;
     int    verbose;
     int    saturate;
   };
@@ -75,23 +75,23 @@ namespace Algo {
   public:
     TopHadBuilder(int =0);
     ~TopHadBuilder();
-    void   init(const FinalState& , const Object&, const size_t&);
+    void   init(const FinalState::FinalState& , const Object&, const std::size_t);
     double eval ( const double* , LV&) ;
     void   print(ostream&);     
-    Decay  get_decay();
-    vector<size_t> get_variables();
+    Decay::Decay  get_decay();
+    vector<std::size_t> get_variables();
   private:    
     LV p4_q;
     LV p4_qbar;
     LV p4_b;
-    size_t index_q;
-    size_t index_qbar;
-    size_t index_b;
+    std::size_t index_q;
+    std::size_t index_qbar;
+    std::size_t index_b;
     TransferFunction* tf_q;
     TransferFunction* tf_qbar;
     TransferFunction* tf_b;
-    Decay  decay;
-    size_t errFlag;
+    Decay::Decay  decay;
+    std::size_t errFlag;
     int    verbose;
     int    qbar_lost;
   };
@@ -100,20 +100,20 @@ namespace Algo {
   public:
     WHadBuilder(int =0);
     ~WHadBuilder();
-    void   init(const FinalState& , const Object&, const size_t&);
+    void   init(const FinalState::FinalState& , const Object&, const std::size_t);
     double eval ( const double* , LV&) ;
     void   print(ostream&);     
-    Decay  get_decay();
-    vector<size_t> get_variables();
+    Decay::Decay  get_decay();
+    vector<std::size_t> get_variables();
   private:
     LV p4_q;
     LV p4_qbar;
-    size_t index_q;
-    size_t index_qbar;
+    std::size_t index_q;
+    std::size_t index_qbar;
     TransferFunction* tf_q;
     TransferFunction* tf_qbar;
-    Decay  decay;
-    size_t errFlag;
+    Decay::Decay  decay;
+    std::size_t errFlag;
     int    verbose;
   };
 
@@ -121,36 +121,36 @@ namespace Algo {
   public:
     TopLepBuilder(int =0);
     ~TopLepBuilder();
-    void   init(const FinalState& , const Object&, const size_t&);
+    void   init(const FinalState::FinalState& , const Object&, const std::size_t);
     double eval ( const double* , LV&) ;
     void   print(ostream&);     
-    Decay  get_decay();
-    vector<size_t> get_variables();
+    Decay::Decay  get_decay();
+    vector<std::size_t> get_variables();
   private:    
     LV p4_l;
     LV p4_b;
-    size_t index_l;
-    size_t index_b;
+    std::size_t index_l;
+    std::size_t index_b;
     TransferFunction* tf_b;
-    Decay  decay;
-    size_t errFlag;
+    Decay::Decay  decay;
+    std::size_t errFlag;
     int    verbose;
   };
   
   class RadiationBuilder : public DecayBuilder {    
   public:
-    RadiationBuilder(int =0, Algo::Decay =Decay::Radiation_g);
+    RadiationBuilder(int =0, Decay::Decay = Decay::Radiation_g);
     ~RadiationBuilder();
-    void   init(const FinalState& , const Object&, const size_t&);
+    void   init(const FinalState::FinalState& , const Object&, const std::size_t);
     double eval ( const double* , LV&) ;    
     void   print(ostream&);     
-    Decay  get_decay();
-    vector<size_t> get_variables();
+    Decay::Decay  get_decay();
+    vector<std::size_t> get_variables();
   private:
     LV p4_g;
-    size_t index_g;
+    std::size_t index_g;
     TransferFunction* tf_g;
-    Decay decay;
+    Decay::Decay decay;
     int   verbose;
   };
  
@@ -158,20 +158,20 @@ namespace Algo {
   public:
     HiggsBuilder(int =0);
     ~HiggsBuilder();
-    void   init(const FinalState& , const Object&, const size_t&);
+    void   init(const FinalState::FinalState& , const Object&, const std::size_t);
     double eval ( const double* , LV&) ;
     void   print(ostream&);     
-    Decay  get_decay();
-    vector<size_t> get_variables();
+    Decay::Decay  get_decay();
+    vector<std::size_t> get_variables();
   private:
     LV p4_b;
     LV p4_bbar;
-    size_t index_b;
-    size_t index_bbar;
+    std::size_t index_b;
+    std::size_t index_bbar;
     TransferFunction* tf_b;
     TransferFunction* tf_bbar;
-    Decay  decay;
-    size_t errFlag;
+    Decay::Decay  decay;
+    std::size_t errFlag;
     int    verbose;
   };
 

--- a/interface/ToyGenerator.h
+++ b/interface/ToyGenerator.h
@@ -32,12 +32,12 @@ namespace Algo {
     ToyGenerator(const int);
     ToyGenerator(const int, const unsigned int);
     ~ToyGenerator();
-    vector<Algo::Object> generate( const vector<Algo::Decay>& , const int&, const int&);
+    vector<Algo::Object> generate( const vector<Algo::Decay::Decay>& , const int&, const int&);
 
   private:
     int verbose;
     int seed_strategy;
-    void generate_hypo( vector<Algo::Object>& , Algo::Decay, const int&, const int&);
+    void generate_hypo( vector<Algo::Object>& , Algo::Decay::Decay, const int&, const int&);
     void assign_rnd_btag( const Algo::QuarkType, Algo::Object&, const int&);
     void smear_by_TF( TLorentzVector&, const char);
     TRandom3* ran;

--- a/interface/Utils.h
+++ b/interface/Utils.h
@@ -18,23 +18,29 @@
 #include<algorithm>
 #include<assert.h>
 #include<memory> 
-#include<limits> 
+#include<limits>
+
+#ifndef __GCCXML__
 #include<chrono>
+#endif
 
 typedef TLorentzVector LV;
 
 using namespace std;
+
+#ifndef __GCCXML__
 using namespace std::chrono;
+#endif
 
 namespace Algo {
 
-  constexpr double MTOP = 174.3;
-  constexpr double MB   = 4.8;
-  constexpr double MW   = 80.19;
-  constexpr double DM2  = (MTOP*MTOP-MB*MB-MW*MW)*0.5;
-  constexpr double MH   = 125.;
-  constexpr double DMH2 = (MH*MH-2*MB*MB)*0.5;
-  constexpr double PTTHRESHOLD = 30.;
+  const double MTOP = 174.3;
+  const double MB   = 4.8;
+  const double MW   = 80.19;
+  const double DM2  = (MTOP*MTOP-MB*MB-MW*MW)*0.5;
+  const double MH   = 125.;
+  const double DMH2 = (MH*MH-2*MB*MB)*0.5;
+  const double PTTHRESHOLD = 30.;
   
   const string TF_Q     = "TMath::Gaus(x, [0] + [1]*y, y*TMath::Sqrt([2]*[2]+[3]*[3]/y+[4]*[4]/y/y), 1)";
   const string TF_Q_CUM = "(1 - 0.5*(TMath::Erf(  (x-([0] + [1]*y)) / (y*TMath::Sqrt([2]*[2]+[3]*[3]/y+[4]*[4]/y/y)) ) + 1 ))";
@@ -70,16 +76,19 @@ namespace Algo {
        {0.30, 0.70}
      };
 
-  enum QuarkType : int { QuarkTypeUp=0, QuarkTypeDown=1, QuarkTypeCharm=2, QuarkTypeBottom=3};
+  enum QuarkType { QuarkTypeUp=0, QuarkTypeDown=1, QuarkTypeCharm=2, QuarkTypeBottom=3};
 
   double pdf_btag(double*, double*);
-  size_t eta_to_bin( const double& );
-  size_t eta_to_bin( const LV& );
+  std::size_t eta_to_bin( const double& );
+  std::size_t eta_to_bin( const LV& );
  
-  enum class Decay { TopLep=0, TopHad, TopHadLost, WHad, Higgs, Radiation_u, Radiation_d, Radiation_c, Radiation_b, Radiation_g, Lepton, MET, UNKNOWN };
+  namespace Decay {
+  enum Decay { TopLep=0, TopHad, TopHadLost, WHad, Higgs, Radiation_u, Radiation_d, Radiation_c, Radiation_b, Radiation_g, Lepton, MET, UNKNOWN };
   string translateDecay(Decay&);
-
-  enum class FinalState { 
+  }
+  
+  namespace FinalState {
+  enum FinalState { 
       TopLep_l=0,        // lep   from top decay   () 
       TopLep_b=1,        // b     from top decay   (TF and btag[B])
       TopHad_q=2,        // q     from top decay   (TF and btag[0.5*LF+0.5*C])
@@ -96,14 +105,16 @@ namespace Algo {
       Radiation_b=13,    // extra quark            (TF and btag[B])  
       Radiation_g=14     // extra quark            (TF, no flavour assignment)  
       };
-
+  }
+  
+  
   struct CompFinalState {
-    bool operator()(pair<FinalState,size_t> a, pair<FinalState,size_t> b){
+    bool operator()(pair<FinalState::FinalState,std::size_t> a, pair<FinalState::FinalState,std::size_t> b){
       return (a.first>b.first) || (a.first==b.first && a.second>b.second);
     }
   };
   
-  FinalState partner(const FinalState fs);
+  FinalState::FinalState partner(const FinalState::FinalState fs);
 
   struct Object {   
     LV p4;
@@ -119,16 +130,16 @@ namespace Algo {
     }
   };
 
-  int diff( const vector<std::pair<FinalState,size_t>>&, 
-	    const vector<std::pair<FinalState,size_t>>&,
+  int diff( const vector<std::pair<FinalState::FinalState,std::size_t> >&, 
+	    const vector<std::pair<FinalState::FinalState,std::size_t> >&,
 	    const vector<Algo::Object>&);
 
-  bool filter_by_btag( const vector<std::pair<FinalState,size_t>>&,
+  bool filter_by_btag( const vector<std::pair<FinalState::FinalState,std::size_t> >&,
 		       const vector<Algo::Object>&  );
 
-  bool isRadiation(const FinalState);
+  bool isRadiation(const FinalState::FinalState);
 
-  enum Strategy : int { FirstTrial=0, StartFromLastMinimum=1 };
+  enum Strategy { FirstTrial=0, StartFromLastMinimum=1 };
 
 }
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -7,6 +7,12 @@ Algo::Event::Event( TTree* t ){
 }
 
 
+Algo::Event::Event(){
+  outTree = nullptr;
+}
+
+
+
 Algo::Event::~Event(){ };
 
 void Algo::Event::fillTree(){

--- a/src/HypoTester.cpp
+++ b/src/HypoTester.cpp
@@ -94,7 +94,7 @@ void Algo::HypoTester::add_object_observables( const string& name, const double&
 }
 
 
-void Algo::HypoTester::test( const map<string, vector<Decay>>& all ){
+void Algo::HypoTester::test( const map<string, vector<Decay::Decay>>& all ){
 
   // benchmark time: start clock for global timing
   auto t0 = high_resolution_clock::now();
@@ -184,7 +184,7 @@ void Algo::HypoTester::next_event(){
   delete minimizer;
 }
 
-void Algo::HypoTester::assume( Decay decay ){
+void Algo::HypoTester::assume( Decay::Decay decay ){
   decays.push_back( decay );
 }
 
@@ -212,34 +212,34 @@ void Algo::HypoTester::unpack_assumptions(){
 
    switch( decay ){
 
-   case Algo::Decay::TopHad:
-     particles.push_back( make_pair( FinalState::TopHad_q,    count_TopHad) );
-     particles.push_back( make_pair( FinalState::TopHad_qbar, count_TopHad) );
-     particles.push_back( make_pair( FinalState::TopHad_b,    count_TopHad) );
+   case Algo::Decay::Decay::TopHad:
+     particles.push_back( make_pair( FinalState::FinalState::TopHad_q,    count_TopHad) );
+     particles.push_back( make_pair( FinalState::FinalState::TopHad_qbar, count_TopHad) );
+     particles.push_back( make_pair( FinalState::FinalState::TopHad_b,    count_TopHad) );
      ++count_TopHad;
      nParam_j += 3;
      if(verbose>0){ cout << "\tAdded TopHad" << endl; }
      break;
 
-   case Algo::Decay::TopHadLost:
-     particles.push_back( make_pair( FinalState::TopHad_q,        count_TopHadLost) );
-     particles.push_back( make_pair( FinalState::TopHad_b,        count_TopHadLost) );
+   case Algo::Decay::Decay::TopHadLost:
+     particles.push_back( make_pair( FinalState::FinalState::TopHad_q,        count_TopHadLost) );
+     particles.push_back( make_pair( FinalState::FinalState::TopHad_b,        count_TopHadLost) );
      ++count_TopHadLost;
      nParam_j += 2;
      nParam_m += 2;
      if(verbose>0){ cout << "\tAdded TopHadLost" << endl; }
      break;
 
-   case Algo::Decay::WHad:
-     particles.push_back( make_pair( FinalState::WHad_q,    count_WHad) );
-     particles.push_back( make_pair( FinalState::WHad_qbar, count_WHad) );
+   case Algo::Decay::Decay::WHad:
+     particles.push_back( make_pair( FinalState::FinalState::WHad_q,    count_WHad) );
+     particles.push_back( make_pair( FinalState::FinalState::WHad_qbar, count_WHad) );
      ++count_WHad;
      nParam_j += 2;
      if(verbose>0){ cout << "\tAdded WHad" << endl; }
      break;
 
-   case Algo::Decay::TopLep:
-     particles.push_back( make_pair( FinalState::TopLep_b,    count_TopLep) );
+   case Algo::Decay::Decay::TopLep:
+     particles.push_back( make_pair( FinalState::FinalState::TopLep_b,    count_TopLep) );
      ++count_TopLep;
      ++invisible;
      nParam_j += 1;
@@ -247,44 +247,44 @@ void Algo::HypoTester::unpack_assumptions(){
      if(verbose>0){ cout << "\tAdded TopLep" << endl; }
      break;
 
-   case Algo::Decay::Higgs:
-     particles.push_back( make_pair( FinalState::Higgs_b,    count_Higgs) );
-     particles.push_back( make_pair( FinalState::Higgs_bbar, count_Higgs) );
+   case Algo::Decay::Decay::Higgs:
+     particles.push_back( make_pair( FinalState::FinalState::Higgs_b,    count_Higgs) );
+     particles.push_back( make_pair( FinalState::FinalState::Higgs_bbar, count_Higgs) );
      ++count_Higgs;
      nParam_j += 2;
      if(verbose>0){ cout << "\tAdded Higgs" << endl; }
      break;
 
-   case Algo::Decay::Radiation_u:
-     particles.push_back( make_pair( FinalState::Radiation_u,   count_Radiation_u) );
+   case Algo::Decay::Decay::Radiation_u:
+     particles.push_back( make_pair( FinalState::FinalState::Radiation_u,   count_Radiation_u) );
      if(verbose>0){ cout << "\tAdded Radiation (u)" << endl; }
      ++count_Radiation_u;
      nParam_j += 1;
      break;
 
-   case Algo::Decay::Radiation_d:
-     particles.push_back( make_pair( FinalState::Radiation_d,   count_Radiation_d) );
+   case Algo::Decay::Decay::Radiation_d:
+     particles.push_back( make_pair( FinalState::FinalState::Radiation_d,   count_Radiation_d) );
      if(verbose>0){ cout << "\tAdded Radiation (d)" << endl; }
      ++count_Radiation_d;
      nParam_j += 1;
      break;
 
-   case Algo::Decay::Radiation_c:
-     particles.push_back( make_pair( FinalState::Radiation_c,   count_Radiation_c) );
+   case Algo::Decay::Decay::Radiation_c:
+     particles.push_back( make_pair( FinalState::FinalState::Radiation_c,   count_Radiation_c) );
      if(verbose>0){ cout << "\tAdded Radiation (c)" << endl; }
      ++count_Radiation_c;
      nParam_j += 1;
      break;
 
-   case Algo::Decay::Radiation_b:
-     particles.push_back( make_pair( FinalState::Radiation_b,   count_Radiation_b) );
+   case Algo::Decay::Decay::Radiation_b:
+     particles.push_back( make_pair( FinalState::FinalState::Radiation_b,   count_Radiation_b) );
      if(verbose>0){ cout << "\tAdded Radiation (b)" << endl; }
      ++count_Radiation_b;
      nParam_j += 1;
      break;
 
-   case Algo::Decay::Radiation_g:
-     particles.push_back( make_pair( FinalState::Radiation_g,   count_Radiation_g) );
+   case Algo::Decay::Decay::Radiation_g:
+     particles.push_back( make_pair( FinalState::FinalState::Radiation_g,   count_Radiation_g) );
      if(verbose>0){ cout << "\tAdded Radiation (g)" << endl; }
      ++count_Radiation_g;
      nParam_j += 1;
@@ -302,7 +302,7 @@ void Algo::HypoTester::unpack_assumptions(){
 
     size_t addradiation = p4_Jet.size()-particles.size();
     while( addradiation > 0){
-      particles.push_back( make_pair( FinalState::Radiation_g,   count_Radiation_g) );
+      particles.push_back( make_pair( FinalState::FinalState::Radiation_g,   count_Radiation_g) );
       if(verbose>0){ cout << "\tAdded Radiation (g)" << endl; }
       ++count_Radiation_g;
       nParam_j += 1;
@@ -342,7 +342,7 @@ void Algo::HypoTester::init(){
   count_perm = 0;
 
   // bookkeep to remove unnecessary permutations
-  vector<vector<std::pair<FinalState,size_t>>> logbook;
+  vector<vector<std::pair<FinalState::FinalState,size_t>>> logbook;
 
   // permutations using std library
   do {            
@@ -368,7 +368,7 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
   
   if(verbose>2){ cout << "Algo::HypoTester::group_particles()" << endl; }
   
-  vector<DecayBuilder*> decayed;
+  vector<Algo::DecayBuilder*> decayed;
   
   //  get all hadronically decaying tops
   for( size_t t_had = 0; t_had < count_TopHad; ++t_had ){
@@ -389,7 +389,7 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
     Algo::TopHadBuilder* topHadLost = new Algo::TopHadBuilder(verbose);
     Object dummy;
     dummy.init( LV(0.,0.,0.,0.), 'j');
-    topHadLost->init( FinalState::TopHadLost_qbar , dummy , 2*t_had_lost + nParam_j + nParam_n ); // offset
+    topHadLost->init( FinalState::FinalState::TopHadLost_qbar , dummy , 2*t_had_lost + nParam_j + nParam_n ); // offset
     size_t pos = 0;
     for( auto part : particles ){
       if( part.second == t_had_lost ){
@@ -417,7 +417,7 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
   for( size_t t_lep = 0; t_lep < count_TopLep; ++t_lep ){
     if(verbose>1) cout << "\tProcessing " << t_lep << "th TopLep" << endl;
     Algo::TopLepBuilder* topLep = new Algo::TopLepBuilder(verbose);   
-    topLep->init( FinalState::TopLep_l , p4_Lepton[t_lep] , 2*t_lep + nParam_j ); // offset
+    topLep->init( FinalState::FinalState::TopLep_l , p4_Lepton[t_lep] , 2*t_lep + nParam_j ); // offset
     size_t pos = 0;
     for( auto part : particles ){
       if( part.second == t_lep ) 
@@ -430,10 +430,10 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
   //  get all radiation
   for( size_t r_had_u = 0; r_had_u < count_Radiation_u; ++r_had_u ){
     if(verbose>1) cout << "\tProcessing " << r_had_u << "th Radiaton (u)" << endl;
-    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Radiation_u);    
+    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Decay::Radiation_u);    
     size_t pos = 0;
     for( auto part : particles ){
-      if( part.second == r_had_u && part.first==FinalState::Radiation_u )  
+      if( part.second == r_had_u && part.first==FinalState::FinalState::Radiation_u )  
 	rad->init( part.first, p4_Jet[pos] , pos );
       ++pos;
     }
@@ -442,10 +442,10 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
 
   for( size_t r_had_d = 0; r_had_d < count_Radiation_d; ++r_had_d ){
     if(verbose>1) cout << "\tProcessing " << r_had_d << "th Radiaton (d)" << endl;
-    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Radiation_d);
+    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Decay::Radiation_d);
     size_t pos = 0;
     for( auto part : particles ){
-      if( part.second == r_had_d && part.first==FinalState::Radiation_d )
+      if( part.second == r_had_d && part.first==FinalState::FinalState::Radiation_d )
         rad->init( part.first, p4_Jet[pos] , pos );
       ++pos;
     }
@@ -454,10 +454,10 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
 
   for( size_t r_had_c = 0; r_had_c < count_Radiation_c; ++r_had_c ){
     if(verbose>1) cout << "\tProcessing " << r_had_c << "th Radiaton (c)" << endl;
-    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Radiation_c);
+    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Decay::Radiation_c);
     size_t pos = 0;
     for( auto part : particles ){
-      if( part.second == r_had_c && part.first==FinalState::Radiation_c )
+      if( part.second == r_had_c && part.first==FinalState::FinalState::Radiation_c )
         rad->init( part.first, p4_Jet[pos] , pos );
       ++pos;
     }
@@ -467,10 +467,10 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
   //  get all radiation                                                                                                                  
   for( size_t r_had_b = 0; r_had_b < count_Radiation_b; ++r_had_b ){
     if(verbose>1) cout << "\tProcessing " << r_had_b << "th Radiaton (b)" << endl;
-    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Radiation_b);
+    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Decay::Radiation_b);
     size_t pos = 0;
     for( auto part : particles ){
-      if( part.second == r_had_b && part.first==FinalState::Radiation_b )
+      if( part.second == r_had_b && part.first==FinalState::FinalState::Radiation_b )
         rad->init( part.first, p4_Jet[pos] , pos );
       ++pos;
     }
@@ -479,10 +479,10 @@ vector<Algo::DecayBuilder*> Algo::HypoTester::group_particles(){
 
   for( size_t r_had_g = 0; r_had_g < count_Radiation_g; ++r_had_g ){
     if(verbose>1) cout << "\tProcessing " << r_had_g << "th Radiaton (g)" << endl;
-    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Radiation_g);
+    Algo::RadiationBuilder* rad = new Algo::RadiationBuilder(verbose, Decay::Decay::Radiation_g);
     size_t pos = 0;
     for( auto part : particles ){
-      if( part.second == r_had_g && part.first==FinalState::Radiation_g )
+      if( part.second == r_had_g && part.first==FinalState::FinalState::Radiation_g )
         rad->init( part.first, p4_Jet[pos] , pos );
       ++pos;
     }
@@ -783,35 +783,35 @@ bool Algo::HypoTester::is_variable_used( const size_t pos ){
   for( auto perm : permutations ){
     for(size_t i = 0 ; i < perm->size() ; ++i){
 
-      DecayBuilder* decay = perm->at(i);
+      Algo::DecayBuilder* decay = perm->at(i);
       vector<size_t> vars ;
 
       switch( decay->get_decay() ){
-      case Decay::TopHad:
+      case Decay::Decay::TopHad:
 	vars = (static_cast<TopHadBuilder*>(decay))->get_variables();
 	if( pos==vars[0] ||  pos==vars[1] ||  pos==vars[2] ) return true;
 	break;
-      case Decay::TopHadLost:
+      case Decay::Decay::TopHadLost:
 	vars = (static_cast<TopHadBuilder*>(decay))->get_variables();
 	if( pos==vars[0] ) return true;
 	break;
-      case Decay::WHad:
+      case Decay::Decay::WHad:
 	vars = (static_cast<WHadBuilder*>(decay))->get_variables();
 	if( pos==vars[0] ) return true; 
 	break;
-      case Decay::Higgs:
+      case Decay::Decay::Higgs:
 	vars = (static_cast<HiggsBuilder*>(decay))->get_variables();  
 	if( pos==vars[0] ) return true; 
 	break;
-      case Decay::TopLep:
+      case Decay::Decay::TopLep:
 	vars = (static_cast<TopLepBuilder*>(decay))->get_variables(); 
 	if( pos==vars[0] || pos==vars[1] ) return true;
 	break;
-      case Decay::Radiation_u:
-      case Decay::Radiation_d:
-      case Decay::Radiation_c:
-      case Decay::Radiation_g:
-      case Decay::Radiation_b:
+      case Decay::Decay::Radiation_u:
+      case Decay::Decay::Radiation_d:
+      case Decay::Decay::Radiation_c:
+      case Decay::Decay::Radiation_g:
+      case Decay::Decay::Radiation_b:
 	vars = (static_cast<RadiationBuilder*>(decay))->get_variables();
         if( pos==vars[0] ) return true;
         break;
@@ -858,9 +858,9 @@ void Algo::HypoTester::print(ostream& os){
     ++count_m;
   }
 
-  os << " -Decays:" << endl;
+  os << " -Decay::Decays:" << endl;
   for( auto decay : decays )
-    os << "\t" << int(decay) << " (=" << Algo::translateDecay(decay)  << ")" << endl;
+    os << "\t" << int(decay) << " (=" << Algo::Decay::translateDecay(decay)  << ")" << endl;
 
   os << " -Partons:" << endl;
   int count_all = 0;  
@@ -895,7 +895,7 @@ void Algo::HypoTester::save_global_variables() {
   } 
 }
 
-void Algo::HypoTester::print_permutation(const vector<std::pair<Algo::FinalState,size_t>>& perm) const {
+void Algo::HypoTester::print_permutation(const vector<std::pair<Algo::FinalState::FinalState,size_t>>& perm) const {
   size_t count{0};
   cout << "\t[";
   for(auto p : perm){
@@ -905,7 +905,7 @@ void Algo::HypoTester::print_permutation(const vector<std::pair<Algo::FinalState
   cout << "]" << endl;
 }
 
-bool Algo::HypoTester::go_to_next(vector<vector<std::pair<Algo::FinalState,size_t>>> & logbook){
+bool Algo::HypoTester::go_to_next(vector<vector<std::pair<Algo::FinalState::FinalState,size_t>>> & logbook){
 
   // filter out permutations with invalid quark <-> jet assignment                                                                                     
   // (only if BTAG_RND is filled and its value less than 0.5)                                                                                          

--- a/src/Integrand.cpp
+++ b/src/Integrand.cpp
@@ -454,12 +454,12 @@ bool MEM::Integrand::accept_perm( const vector<int>& perm ){
 
   switch( fs ){
   case FinalState::LH:
-    if(perm[0]>=0 && obs_jets[perm[0]].getObs(Observable::BTAG)>0.5) return false; // <== W->qq
-    if(perm[1]>=0 && obs_jets[perm[1]].getObs(Observable::BTAG)>0.5) return false; // <== W->qq
-    if(perm[2]>=0 && obs_jets[perm[2]].getObs(Observable::BTAG)<0.5) return false; // <== t->b
-    if(perm[3]>=0 && obs_jets[perm[3]].getObs(Observable::BTAG)<0.5) return false; // <== t->b
-    if(perm[4]>=0 && obs_jets[perm[4]].getObs(Observable::BTAG)<0.5) return false; // <== H->bb
-    if(perm[5]>=0 && obs_jets[perm[5]].getObs(Observable::BTAG)<0.5) return false; // <== H->bb
+    if(perm[0]>=0 && obs_jets[perm[0]]->getObs(Observable::BTAG)>0.5) return false; // <== W->qq
+    if(perm[1]>=0 && obs_jets[perm[1]]->getObs(Observable::BTAG)>0.5) return false; // <== W->qq
+    if(perm[2]>=0 && obs_jets[perm[2]]->getObs(Observable::BTAG)<0.5) return false; // <== t->b
+    if(perm[3]>=0 && obs_jets[perm[3]]->getObs(Observable::BTAG)<0.5) return false; // <== t->b
+    if(perm[4]>=0 && obs_jets[perm[4]]->getObs(Observable::BTAG)<0.5) return false; // <== H->bb
+    if(perm[5]>=0 && obs_jets[perm[5]]->getObs(Observable::BTAG)<0.5) return false; // <== H->bb
 
     //for( auto visited : perm_indexes_assumption ){
     //bool swap_W = visited[2]==perm[2];
@@ -817,9 +817,9 @@ double MEM::Integrand::probability(const double* x, const vector<int>& perm ) co
 	 << ", m(H)=" << (lv_b+lv_bbar).M() << endl;
   }
 
-  m *= t_decay_amplitude(lv_q1, lv_qbar1, lv_b1);
-  m *= t_decay_amplitude(lv_q2, lv_qbar2, lv_b2);
-  m *= (hypo==Hypothesis::TTH ? H_decay_amplitude(lv_b, lv_bbar) : 1.0 );
+  m *= t_Decay_amplitude(lv_q1, lv_qbar1, lv_b1);
+  m *= t_Decay_amplitude(lv_q2, lv_qbar2, lv_b2);
+  m *= (hypo==Hypothesis::TTH ? H_Decay_amplitude(lv_b, lv_bbar) : 1.0 );
   m *= scattering( lv_q1+lv_qbar1+lv_b1, lv_q2+lv_qbar2+lv_b2, lv_b, lv_bbar, x1, x2);
   m *= pdf( x1, x2 , hypo==Hypothesis::TTH ? (2*MTOP + MH)/2 : TMath::Sqrt( 4*MTOP*MTOP + TMath::Power(lv_b.Pt() + lv_bbar.Pt(), 2) )  );
 
@@ -964,12 +964,12 @@ double MEM::Integrand::pdf(const double& x1, const double& x2, const double& Q) 
   return (f1*f2)/(x1*x2);
 }
 
-double MEM::Integrand::t_decay_amplitude(const TLorentzVector&, const TLorentzVector&, const TLorentzVector&) const{
+double MEM::Integrand::t_Decay_amplitude(const TLorentzVector&, const TLorentzVector&, const TLorentzVector&) const{
   double p{1.};
   return p;
 }
 
-double MEM::Integrand::H_decay_amplitude(const TLorentzVector&, const TLorentzVector&) const{
+double MEM::Integrand::H_Decay_amplitude(const TLorentzVector&, const TLorentzVector&) const{
   double p{1.};
   return p;
 }

--- a/src/StandardIncludes.cpp
+++ b/src/StandardIncludes.cpp
@@ -74,8 +74,8 @@ void Algo::TransferFunction::init(const double* param){
 
 //////////////////////////////////////////////////////
 
-Algo::CombBuilder::CombBuilder(vector<DecayBuilder*>&& comb, int verb) {
-  combined = move(comb);
+Algo::CombBuilder::CombBuilder(vector<DecayBuilder*> comb, int verb) {
+  combined = comb;
   verbose  = verb;
 }
 
@@ -126,23 +126,23 @@ void Algo::CombBuilder::print(ostream& os){
     comb->print(os);
 }
 
-Algo::DecayBuilder* Algo::CombBuilder::at( const size_t& pos ){
-  return ( (pos>=0 && pos<combined.size()) ? combined[pos] : nullptr);
+Algo::DecayBuilder* Algo::CombBuilder::at( const std::size_t pos ){
+  return ( (pos<combined.size()) ? combined[pos] : nullptr);
 }
 
-size_t Algo::CombBuilder::size(){
+std::size_t Algo::CombBuilder::size(){
   return combined.size();
 }
 
-Algo::Decay Algo::CombBuilder::get_decay(){
-  return Decay::UNKNOWN;
+Algo::Decay::Decay Algo::CombBuilder::get_decay(){
+  return Decay::Decay::UNKNOWN;
 }
 
 //////////////////////////////////////////////////////
 
 
 Algo::METBuilder::METBuilder(int verb) {
-  decay    = Decay::MET;
+  decay    = Decay::Decay::MET;
   tf_met   = nullptr;
   verbose  = verb;
   saturate = 0;
@@ -180,19 +180,19 @@ double Algo::METBuilder::eval(const double* xx,  LV& lv) {
 
 
 void Algo::METBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " <<  Algo::translateDecay(decay) <<  endl; 
+  os << "\t\t\tDecay: " <<  Algo::Decay::translateDecay(decay) <<  endl; 
   os << "\t\t\tMET:   p4 = (" << p4_invisible.Pt() << ", " << p4_invisible.Phi() << ")" << endl;
   if(tf_met!=nullptr)  os << "\t\t\tTF MET   : " << tf_met->getFormula() << endl;
 }
 
-Algo::Decay Algo::METBuilder::get_decay(){
+Algo::Decay::Decay Algo::METBuilder::get_decay(){
   return decay;
 }
 
 //////////////////////////////////////////////////////
 
 Algo::TopHadBuilder::TopHadBuilder (int verb) {
-  decay     = Decay::TopHad;
+  decay     = Decay::Decay::TopHad;
   errFlag   = 0;
   tf_q      = nullptr;
   tf_qbar   = nullptr;
@@ -209,7 +209,7 @@ Algo::TopHadBuilder::~TopHadBuilder() {
 }
 
 void Algo::TopHadBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " <<  Algo::translateDecay(decay) << endl; 
+  os << "\t\t\tDecay: " <<  Algo::Decay::translateDecay(decay) << endl; 
   os << "\t\t\tq    [" << index_q    << "]: p4 = (" << p4_q.Pt() << ", " << p4_q.Eta()  << ", " << p4_q.Phi() << ", " << p4_q.M() << ")" << endl; 
   if(qbar_lost==0)
     os << "\t\t\tqbar [" << index_qbar << "]: p4 = (" << p4_qbar.Pt() << ", " << p4_qbar.Eta()  << ", " << p4_qbar.Phi() << ", " << p4_qbar.M() << ")" <<endl; 
@@ -221,12 +221,12 @@ void Algo::TopHadBuilder::print(ostream& os){
 
 
 
-void Algo::TopHadBuilder::init( const FinalState& fs, const Object& obj, const size_t& sz ){
+void Algo::TopHadBuilder::init( const FinalState::FinalState& fs, const Object& obj, const std::size_t sz ){
 
   TransferFunction* tf = nullptr;
 
   switch( fs ){
-  case FinalState::TopHad_q:
+  case FinalState::FinalState::TopHad_q:
     p4_q    = obj.p4;
     index_q = sz;
     tf = new TransferFunction("tf_q", TF_Q, verbose);    
@@ -234,7 +234,7 @@ void Algo::TopHadBuilder::init( const FinalState& fs, const Object& obj, const s
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeUp );      
     tf_q    = tf;
     break;
-  case FinalState::TopHad_qbar:
+  case FinalState::FinalState::TopHad_qbar:
     p4_qbar    = obj.p4;
     index_qbar = sz;
     tf = new TransferFunction("tf_qbar", TF_Q , verbose);
@@ -242,14 +242,14 @@ void Algo::TopHadBuilder::init( const FinalState& fs, const Object& obj, const s
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeDown );      
     tf_qbar    = tf;
     break;
-  case FinalState::TopHadLost_qbar:
+  case FinalState::FinalState::TopHadLost_qbar:
     index_qbar = sz;
     tf = new TransferFunction("tfLost_qbar", TF_Q_CUM , verbose);
     tf->set_threshold(PTTHRESHOLD);
     tf_qbar    = tf;
     ++qbar_lost;
     break;
-  case FinalState::TopHad_b:
+  case FinalState::FinalState::TopHad_b:
     p4_b    = obj.p4;
     index_b = sz;
     tf = new TransferFunction("tf_b", TF_B , verbose);
@@ -371,12 +371,12 @@ double Algo::TopHadBuilder::eval( const double *xx, LV& invisible ) {
   return val;
 }
 
-Algo::Decay Algo::TopHadBuilder::get_decay(){
+Algo::Decay::Decay Algo::TopHadBuilder::get_decay(){
   return decay;
 }
 
-vector<size_t> Algo::TopHadBuilder::get_variables(){
-  vector<size_t> out;
+vector<std::size_t> Algo::TopHadBuilder::get_variables(){
+  vector<std::size_t> out;
   out.push_back( index_q );
   if(qbar_lost){
     out.push_back( index_qbar );
@@ -387,7 +387,7 @@ vector<size_t> Algo::TopHadBuilder::get_variables(){
 //////////////////////////////////////////////////////
 
 Algo::WHadBuilder::WHadBuilder (int verb) {
-  decay   = Decay::WHad;
+  decay   = Decay::Decay::WHad;
   errFlag = 0;
   tf_q    = nullptr;
   tf_qbar = nullptr;
@@ -401,7 +401,7 @@ Algo::WHadBuilder::~WHadBuilder() {
 };
 
 void Algo::WHadBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " << Algo::translateDecay(decay) << endl; 
+  os << "\t\t\tDecay: " << Algo::Decay::translateDecay(decay) << endl; 
   os << "\t\t\tq    [" << index_q    << "]: p4 = (" << p4_q.Pt() << ", " << p4_q.Eta()  << ", " << p4_q.Phi() << ", " << p4_q.M() << ")" << endl; 
   os << "\t\t\tqbar [" << index_qbar << "]: p4 = (" << p4_qbar.Pt() << ", " << p4_qbar.Eta()  << ", " << p4_qbar.Phi() << ", " << p4_qbar.M() << ")" <<endl; 
   if(tf_q!=nullptr)    os << "\t\t\tTF q   : " << tf_q->getFormula() << endl;
@@ -409,12 +409,12 @@ void Algo::WHadBuilder::print(ostream& os){
 }
 
 
-void Algo::WHadBuilder::init( const FinalState& fs, const Object& obj, const size_t& sz ){
+void Algo::WHadBuilder::init( const FinalState::FinalState& fs, const Object& obj, const std::size_t sz ){
 
   TransferFunction* tf = nullptr;
 
   switch( fs ){
-  case FinalState::WHad_q:
+  case FinalState::FinalState::WHad_q:
     p4_q    = obj.p4;
     index_q = sz;
     tf = new TransferFunction("tf_q", TF_Q , verbose);
@@ -422,7 +422,7 @@ void Algo::WHadBuilder::init( const FinalState& fs, const Object& obj, const siz
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeUp );      
     tf_q    = tf;
     break;
-  case FinalState::WHad_qbar:
+  case FinalState::FinalState::WHad_qbar:
     p4_qbar    = obj.p4;
     index_qbar = sz;
     tf = new TransferFunction("tf_qbar", TF_Q , verbose);
@@ -468,12 +468,12 @@ double Algo::WHadBuilder::eval( const double *xx, LV& invisible ) {
 
 }
 
-Algo::Decay Algo::WHadBuilder::get_decay(){
+Algo::Decay::Decay Algo::WHadBuilder::get_decay(){
   return decay;
 }
 
-vector<size_t> Algo::WHadBuilder::get_variables(){
-  vector<size_t> out;
+vector<std::size_t> Algo::WHadBuilder::get_variables(){
+  vector<std::size_t> out;
   out.push_back( index_q );
   return out;
 }
@@ -481,7 +481,7 @@ vector<size_t> Algo::WHadBuilder::get_variables(){
 //////////////////////////////////////////////////////
 
 Algo::HiggsBuilder::HiggsBuilder (int verb) {
-  decay   = Decay::Higgs;
+  decay   = Decay::Decay::Higgs;
   errFlag = 0;
   tf_b    = nullptr;
   tf_bbar = nullptr;
@@ -495,7 +495,7 @@ Algo::HiggsBuilder::~HiggsBuilder() {
 };
 
 void Algo::HiggsBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " << Algo::translateDecay(decay) << endl; 
+  os << "\t\t\tDecay: " << Algo::Decay::translateDecay(decay) << endl; 
   os << "\t\t\tb    [" << index_b    << "]: p4 = (" << p4_b.Pt() << ", " << p4_b.Eta()  << ", " << p4_b.Phi() << ", " << p4_b.M() << ")" << endl; 
   os << "\t\t\tbbar [" << index_bbar << "]: p4 = (" << p4_bbar.Pt() << ", " << p4_bbar.Eta()  << ", " << p4_bbar.Phi() << ", " << p4_bbar.M() << ")" <<endl; 
   if(tf_b!=nullptr)    os << "\t\t\tTF b   : " << tf_b->getFormula() << endl;
@@ -504,12 +504,12 @@ void Algo::HiggsBuilder::print(ostream& os){
 
 
 
-void Algo::HiggsBuilder::init( const FinalState& fs, const Object& obj, const size_t& sz ){
+void Algo::HiggsBuilder::init( const FinalState::FinalState& fs, const Object& obj, const std::size_t sz ){
 
   TransferFunction* tf = nullptr;
 
   switch( fs ){
-  case FinalState::Higgs_b:
+  case FinalState::FinalState::Higgs_b:
     p4_b    = obj.p4;
     index_b = sz;
     tf = new TransferFunction("tf_b", TF_B , verbose);
@@ -517,7 +517,7 @@ void Algo::HiggsBuilder::init( const FinalState& fs, const Object& obj, const si
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeBottom );      
     tf_b    = tf;
     break;
-  case FinalState::Higgs_bbar:
+  case FinalState::FinalState::Higgs_bbar:
     p4_bbar    = obj.p4;
     index_bbar = sz;
     tf = new TransferFunction("tf_bbar", TF_B , verbose);
@@ -615,12 +615,12 @@ double Algo::HiggsBuilder::eval( const double *xx, LV& invisible ) {
 
 }
 
-Algo::Decay Algo::HiggsBuilder::get_decay(){
+Algo::Decay::Decay Algo::HiggsBuilder::get_decay(){
   return decay;
 }
 
-vector<size_t> Algo::HiggsBuilder::get_variables(){
-  vector<size_t> out;
+vector<std::size_t> Algo::HiggsBuilder::get_variables(){
+  vector<std::size_t> out;
   out.push_back( index_b );
   return out;
 }
@@ -628,7 +628,7 @@ vector<size_t> Algo::HiggsBuilder::get_variables(){
 //////////////////////////////////////////////////////
 
 Algo::TopLepBuilder::TopLepBuilder (int verb) {
-  decay   = Decay::TopLep;
+  decay   = Decay::Decay::TopLep;
   errFlag = 0;
   tf_b    = nullptr;
   verbose = verb;
@@ -640,7 +640,7 @@ Algo::TopLepBuilder::~TopLepBuilder() {
 }
 
 void Algo::TopLepBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " <<  Algo::translateDecay(decay) << endl; 
+  os << "\t\t\tDecay: " <<  Algo::Decay::translateDecay(decay) << endl; 
   os << "\t\t\tlep  [" << index_l    << "]: p4 = (" << p4_l.Pt() << ", " << p4_l.Eta()  << ", " << p4_l.Phi() << ", " << p4_l.M() << ")" <<endl; 
   os << "\t\t\tb    [" << index_b    << "]: p4 = (" << p4_b.Pt() << ", " << p4_b.Eta()  << ", " << p4_b.Phi() << ", " << p4_b.M() << ")" <<endl; 
   if(tf_b!=nullptr)    os << "\t\t\tTF b   : " << tf_b->getFormula() << endl;
@@ -648,16 +648,16 @@ void Algo::TopLepBuilder::print(ostream& os){
 
 
 
-void Algo::TopLepBuilder::init( const FinalState& fs, const Object& obj, const size_t& sz ){
+void Algo::TopLepBuilder::init( const FinalState::FinalState& fs, const Object& obj, const std::size_t sz ){
 
   TransferFunction* tf = nullptr;
 
   switch( fs ){
-  case FinalState::TopLep_l:
+  case FinalState::FinalState::TopLep_l:
     p4_l    = obj.p4;
     index_l = sz;
     break;
-  case FinalState::TopLep_b:
+  case FinalState::FinalState::TopLep_b:
     p4_b    = obj.p4;
     index_b = sz;
     tf = new TransferFunction("tf_b", TF_B , verbose);
@@ -766,19 +766,19 @@ double Algo::TopLepBuilder::eval( const double *xx, LV& invisible ) {
   
 }
 
-Algo::Decay Algo::TopLepBuilder::get_decay(){
+Algo::Decay::Decay Algo::TopLepBuilder::get_decay(){
   return decay;
 }
 
-vector<size_t> Algo::TopLepBuilder::get_variables(){
-  vector<size_t> out;
+vector<std::size_t> Algo::TopLepBuilder::get_variables(){
+  vector<std::size_t> out;
   out.push_back( index_l );
   out.push_back( index_l + 1);
   return out;
 }
 //////////////////////////////////////////////////////
 
-Algo::RadiationBuilder::RadiationBuilder (int verb, Decay type) { 
+Algo::RadiationBuilder::RadiationBuilder (int verb, Decay::Decay type) { 
   decay   = type;
   verbose = verb;
   tf_g    = nullptr;   
@@ -789,29 +789,29 @@ Algo::RadiationBuilder::~RadiationBuilder() {
   if( tf_g   != nullptr ) delete tf_g;
 };
 
-Algo::Decay Algo::RadiationBuilder::get_decay() {
+Algo::Decay::Decay Algo::RadiationBuilder::get_decay() {
   return decay;
 }
 
-vector<size_t> Algo::RadiationBuilder::get_variables(){
-  vector<size_t> out;
+vector<std::size_t> Algo::RadiationBuilder::get_variables(){
+  vector<std::size_t> out;
   out.push_back( index_g );
   return out;
 }
 
 void Algo::RadiationBuilder::print(ostream& os){
-  os << "\t\t\tDecay: " << Algo::translateDecay(decay) << endl; 
+  os << "\t\t\tDecay: " << Algo::Decay::translateDecay(decay) << endl; 
   os << "\t\t\trad" << "    [" << index_g    << "]: p4 = (" << p4_g.Pt() << ", " << p4_g.Eta()  << ", " << p4_g.Phi() << ", " << p4_g.M() << ")" << endl; 
   if(tf_g!=nullptr)    os << "\t\t\tTF " << tf_g->getFormula() << endl;
 }
 
 
-void Algo::RadiationBuilder::init( const FinalState& fs, const Object& obj, const size_t& sz ){
+void Algo::RadiationBuilder::init( const FinalState::FinalState& fs, const Object& obj, const std::size_t sz ){
 
   TransferFunction* tf = nullptr;
 
   switch( fs ){
-  case FinalState::Radiation_u:
+  case FinalState::FinalState::Radiation_u:
     p4_g    = obj.p4;
     index_g = sz;
     tf = new TransferFunction("tf_q", TF_Q , verbose);
@@ -819,7 +819,7 @@ void Algo::RadiationBuilder::init( const FinalState& fs, const Object& obj, cons
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeUp );      
     tf_g    = tf;
     break;
-  case FinalState::Radiation_d:
+  case FinalState::FinalState::Radiation_d:
     p4_g    = obj.p4;
     index_g = sz;
     tf = new TransferFunction("tf_q", TF_Q , verbose);
@@ -827,7 +827,7 @@ void Algo::RadiationBuilder::init( const FinalState& fs, const Object& obj, cons
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeDown );
     tf_g    = tf;
     break;
-  case FinalState::Radiation_c:
+  case FinalState::FinalState::Radiation_c:
     p4_g    = obj.p4;
     index_g = sz;
     tf = new TransferFunction("tf_q", TF_Q , verbose);
@@ -835,7 +835,7 @@ void Algo::RadiationBuilder::init( const FinalState& fs, const Object& obj, cons
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeCharm );
     tf_g    = tf;
     break;
-  case FinalState::Radiation_b:
+  case FinalState::FinalState::Radiation_b:
     p4_g    = obj.p4;
     index_g = sz;
     tf = new TransferFunction("tf_b", TF_B , verbose);
@@ -843,7 +843,7 @@ void Algo::RadiationBuilder::init( const FinalState& fs, const Object& obj, cons
     for(auto iobs : obj.obs ) tf->add_pdf_obs( iobs.first, obj, Algo::QuarkTypeBottom );      
     tf_g    = tf;
     break;
-  case FinalState::Radiation_g: //do not assume the parton flavour
+  case FinalState::FinalState::Radiation_g: //do not assume the parton flavour
     p4_g    = obj.p4;
     index_g = sz;
     tf = new TransferFunction("tf_q", TF_Q , verbose);

--- a/src/ToyGenerator.cpp
+++ b/src/ToyGenerator.cpp
@@ -22,7 +22,7 @@ Algo::ToyGenerator::~ToyGenerator(){
   delete f_eta_rad;
 }
 
-vector<Algo::Object> Algo::ToyGenerator::generate( const vector<Decay>& decays, const int& smear, const int& btag){
+vector<Algo::Object> Algo::ToyGenerator::generate( const vector<Decay::Decay>& decays, const int& smear, const int& btag){
   
   vector<Algo::Object> output;
 
@@ -35,7 +35,7 @@ vector<Algo::Object> Algo::ToyGenerator::generate( const vector<Decay>& decays, 
 }
 
 
-void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, const int& smear, const int& btag ){
+void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay::Decay type, const int& smear, const int& btag ){
 
   int break_loop = 0;
   double pt_rad  = 20.;
@@ -135,7 +135,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
 
   switch(type){
 
-  case Decay::TopHad:
+  case Decay::Decay::TopHad:
     if(smear){
       smear_by_TF(p4_q,   'q');
       smear_by_TF(p4_qbar,'q');
@@ -153,7 +153,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     out.push_back( out2 );
     out.push_back( out3 );
     break;
-  case Decay::TopHadLost:
+  case Decay::Decay::TopHadLost:
     if(smear){
       smear_by_TF(p4_q,   'q');
       smear_by_TF(p4_b,   'b');
@@ -167,7 +167,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     out.push_back( out1 );
     out.push_back( out3 );
     break;
-  case Decay::TopLep:
+  case Decay::Decay::TopLep:
     if(smear){
       smear_by_TF(p4_b,   'b');
       smear_by_TF(p4_qbar,'m');
@@ -182,7 +182,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     out.push_back( out2 );
     out.push_back( out3 );
     break;
-  case Decay::WHad:
+  case Decay::Decay::WHad:
     if(smear){
       smear_by_TF(p4_q,   'q');
       smear_by_TF(p4_qbar,'q');
@@ -196,7 +196,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     out.push_back( out1 );
     out.push_back( out2 );
     break;
-  case Decay::Higgs:
+  case Decay::Decay::Higgs:
     if(smear){
       smear_by_TF(p4_bh,   'b');
       smear_by_TF(p4_bbarh,'b');
@@ -210,7 +210,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     out.push_back( out1 );
     out.push_back( out2 );
     break;
-  case Decay::Radiation_u:
+  case Decay::Decay::Radiation_u:
     if(smear) 
       smear_by_TF(p4_q, 'q');
     out1.init( p4_q,    'q');
@@ -219,7 +219,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     }
     out.push_back( out1 );
     break;
-  case Decay::Radiation_d:
+  case Decay::Decay::Radiation_d:
     if(smear)
       smear_by_TF(p4_qbar, 'q');
     out1.init( p4_qbar,    'q');
@@ -228,7 +228,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     }
     out.push_back( out1 );
     break;
-  case Decay::Radiation_g:
+  case Decay::Decay::Radiation_g:
     if(smear)
       smear_by_TF(p4_rad, 'q');
     out1.init( p4_rad,    'q');
@@ -237,7 +237,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     }
     out.push_back( out1 );
     break;
-  case Decay::Radiation_c:
+  case Decay::Decay::Radiation_c:
     if(smear)
       smear_by_TF(p4_rad, 'q');
     out1.init( p4_rad,    'q');
@@ -246,7 +246,7 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     }
     out.push_back( out1 );
     break;
-  case Decay::Radiation_b:
+  case Decay::Decay::Radiation_b:
     if(smear)
       smear_by_TF(p4_rad, 'b');
     out1.init( p4_rad,    'b');
@@ -255,11 +255,11 @@ void Algo::ToyGenerator::generate_hypo( vector<Algo::Object>& out, Decay type, c
     }
     out.push_back( out1 );
     break;
-  case Decay::Lepton:
+  case Decay::Decay::Lepton:
     out1.init( p4_q,    'l');
     out.push_back( out1 );
     break;
-  case Decay::MET:
+  case Decay::Decay::MET:
     if(smear)
       smear_by_TF(p4_noise, 'm');
     out1.init( p4_noise,    'm');
@@ -368,7 +368,3 @@ void Algo::ToyGenerator::smear_by_TF(TLorentzVector& lv, char type){
 
   return;
 }
-
-
-
-

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -11,7 +11,6 @@ double Algo::pdf_btag(double* x, double* par){
   if(x==nullptr || par==nullptr) return val;
 
   size_t bin = Algo::eta_to_bin(par[2]);
-  if(bin<0) return val;
 
   Algo::QuarkType type = static_cast<Algo::QuarkType>(static_cast<int>(par[0])); 
   double btag = x[0];
@@ -58,7 +57,7 @@ size_t Algo::eta_to_bin( const LV& lv ){
   return -99;
 }
 
-string Algo::translateDecay(Algo::Decay& decay){
+string Algo::Decay::translateDecay(Algo::Decay::Decay& decay){
   
   string name = "";
   switch( decay ){
@@ -105,8 +104,8 @@ string Algo::translateDecay(Algo::Decay& decay){
 }
 
 
-int Algo::diff( const std::vector<std::pair<FinalState,size_t>>& a, 
-		const std::vector<std::pair<FinalState,size_t>>& b, 
+int Algo::diff( const std::vector<std::pair<FinalState::FinalState,size_t>>& a, 
+		const std::vector<std::pair<FinalState::FinalState,size_t>>& b, 
 		const vector<Algo::Object>& jets){
   
   if(a.size()!=b.size())    return -1;
@@ -119,7 +118,7 @@ int Algo::diff( const std::vector<std::pair<FinalState,size_t>>& a,
     auto id_a = a[i].second;
     auto id_b = b[i].second;
 
-    FinalState fs_abar = Algo::partner(fs_a);
+    FinalState::FinalState fs_abar = Algo::partner(fs_a);
     bool btagd  = (jets[i]).isDiscriminating("BTAG");
     bool same   = (id_a==id_b);
     bool matchL = (fs_abar==fs_b);
@@ -129,26 +128,26 @@ int Algo::diff( const std::vector<std::pair<FinalState,size_t>>& a,
     //matchL = matchT;
 
     switch(fs_a){
-    case FinalState::Radiation_g:
-    case FinalState::Radiation_u:
-    case FinalState::Radiation_d:
-    case FinalState::Radiation_c:
-    case FinalState::Radiation_b:      
+    case FinalState::FinalState::Radiation_g:
+    case FinalState::FinalState::Radiation_u:
+    case FinalState::FinalState::Radiation_d:
+    case FinalState::FinalState::Radiation_c:
+    case FinalState::FinalState::Radiation_b:      
       if( btagd && !(matchT || matchL)) return 1;
       if(!btagd && !israd)  return 2;
       continue;
       break;
-    case FinalState::TopHad_q: 
-    case FinalState::TopHad_qbar:  
-    case FinalState::WHad_q:   
-    case FinalState::WHad_qbar:   
+    case FinalState::FinalState::TopHad_q: 
+    case FinalState::FinalState::TopHad_qbar:  
+    case FinalState::FinalState::WHad_q:   
+    case FinalState::FinalState::WHad_qbar:   
       if(!same)             return 3;
       if( btagd && !matchT) return 4;
       if(!btagd && !(matchL || matchT)) return 5;
       continue;
       break;       
-    case FinalState::Higgs_b: 
-    case FinalState::Higgs_bbar: 
+    case FinalState::FinalState::Higgs_b: 
+    case FinalState::FinalState::Higgs_bbar: 
       if(!same)                return 6;
       if(!(matchL || matchT) ) return 7;        
       continue;
@@ -160,8 +159,8 @@ int Algo::diff( const std::vector<std::pair<FinalState,size_t>>& a,
     }
 
     /*
-    if( !( a[i].first == FinalState::Radiation_u || a[i].first == FinalState::Radiation_d || 
-	   a[i].first == FinalState::Radiation_b || a[i].first == FinalState::Radiation_g )){
+    if( !( a[i].first == FinalState::FinalState::Radiation_u || a[i].first == FinalState::FinalState::Radiation_d || 
+	   a[i].first == FinalState::FinalState::Radiation_b || a[i].first == FinalState::FinalState::Radiation_g )){
       if( a[i].first != b[i].first || a[i].second != b[i].second ) return false;
     }
     else{
@@ -182,7 +181,7 @@ int Algo::diff( const std::vector<std::pair<FinalState,size_t>>& a,
    Input:  a = test, b = target                                                                                                                        
    Output: true if it is a good permutation, false otherwise 
 */
-bool Algo::filter_by_btag( const std::vector<std::pair<FinalState,size_t>>& particles, const vector<Algo::Object>& jets ){
+bool Algo::filter_by_btag( const std::vector<std::pair<FinalState::FinalState,size_t>>& particles, const vector<Algo::Object>& jets ){
   
   bool passes {true};
 
@@ -197,24 +196,24 @@ bool Algo::filter_by_btag( const std::vector<std::pair<FinalState,size_t>>& part
 
     double btag = (jets[count].obs).find("BTAG")->second;
     switch( p.first ){
-    case FinalState::TopHad_q:
-    case FinalState::TopHad_qbar:
-    case FinalState::WHad_q:
-    case FinalState::WHad_qbar:
-    case FinalState::Radiation_u:
-    case FinalState::Radiation_d:
-    case FinalState::Radiation_c:
-    case FinalState::Radiation_g:
+    case FinalState::FinalState::TopHad_q:
+    case FinalState::FinalState::TopHad_qbar:
+    case FinalState::FinalState::WHad_q:
+    case FinalState::FinalState::WHad_qbar:
+    case FinalState::FinalState::Radiation_u:
+    case FinalState::FinalState::Radiation_d:
+    case FinalState::FinalState::Radiation_c:
+    case FinalState::FinalState::Radiation_g:
       if( btag>0.5 ){
 	passes = false;
 	return passes;
       }
       break;
-    case FinalState::TopLep_b:
-    case FinalState::TopHad_b:
-    case FinalState::Higgs_b:
-    case FinalState::Higgs_bbar:
-    case FinalState::Radiation_b:
+    case FinalState::FinalState::TopLep_b:
+    case FinalState::FinalState::TopHad_b:
+    case FinalState::FinalState::Higgs_b:
+    case FinalState::FinalState::Higgs_bbar:
+    case FinalState::FinalState::Radiation_b:
       if( btag<0.5 ){
 	passes = false;
 	return passes;
@@ -229,25 +228,25 @@ bool Algo::filter_by_btag( const std::vector<std::pair<FinalState,size_t>>& part
   return passes;
 }
 
-Algo::FinalState Algo::partner( const Algo::FinalState fs){
+Algo::FinalState::FinalState Algo::partner( const Algo::FinalState::FinalState fs){
   switch( fs ){
-  case FinalState::TopHad_q:
-    return FinalState::TopHad_qbar;
+  case FinalState::FinalState::TopHad_q:
+    return FinalState::FinalState::TopHad_qbar;
     break;
-  case FinalState::TopHad_qbar:
-    return FinalState::TopHad_q;
+  case FinalState::FinalState::TopHad_qbar:
+    return FinalState::FinalState::TopHad_q;
     break;
-  case FinalState::WHad_q:
-    return FinalState::WHad_qbar;
+  case FinalState::FinalState::WHad_q:
+    return FinalState::FinalState::WHad_qbar;
     break;
-  case FinalState::WHad_qbar:
-    return FinalState::WHad_q;
+  case FinalState::FinalState::WHad_qbar:
+    return FinalState::FinalState::WHad_q;
     break;
-  case FinalState::Higgs_b:
-    return FinalState::Higgs_bbar;
+  case FinalState::FinalState::Higgs_b:
+    return FinalState::FinalState::Higgs_bbar;
     break;
-  case FinalState::Higgs_bbar:
-    return FinalState::Higgs_b;
+  case FinalState::FinalState::Higgs_bbar:
+    return FinalState::FinalState::Higgs_b;
     break;
   default:
     return fs;
@@ -256,8 +255,8 @@ Algo::FinalState Algo::partner( const Algo::FinalState fs){
   return fs;
 }
 
-bool Algo::isRadiation( const Algo::FinalState fs ){
-  return (fs==FinalState::Radiation_u || fs==FinalState::Radiation_d || fs==FinalState::Radiation_c || fs==FinalState::Radiation_b || fs==FinalState::Radiation_g);
+bool Algo::isRadiation( const Algo::FinalState::FinalState fs ){
+  return (fs==FinalState::FinalState::Radiation_u || fs==FinalState::FinalState::Radiation_d || fs==FinalState::FinalState::Radiation_c || fs==FinalState::FinalState::Radiation_b || fs==FinalState::FinalState::Radiation_g);
 }
 
 

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,0 +1,14 @@
+#include "TTH/MEIntegratorStandalone/interface/HypoTester.h"
+#include "TTH/MEIntegratorStandalone/interface/Event.h"
+
+//template class map<string, vector<Algo::Decay::Decay> >;
+//template class vector<Algo::Decay::Decay>;
+namespace {
+    namespace {
+        Algo::HypoTester _i1;
+        Algo::Event _i2;
+        Algo::Decay::Decay _i3;
+        std::vector<Algo::Decay::Decay> _i4;
+        std::map<std::string, std::vector<Algo::Decay::Decay> > _i5;
+    }
+}

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,0 +1,7 @@
+<lcgdict>
+        <class name="Algo::HypoTester"/>
+        <class name="Algo::Event"/>
+        <class name="std::vector<Algo::Decay::Decay>"/>
+        <class name="std::map<std::string,std::vector<Algo::Decay::Decay> >"/>
+        <enum name="Algo::Decay::Decay"/>
+</lcgdict>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -51,13 +51,13 @@ int main(){
   met.SetPtEtaPhiM( 0., 0., 0., 0.);
   //tester->push_back_object( met  , 'm');
 
-  map<string, vector<Algo::Decay> > hypotheses;
-  hypotheses["H0"] = {Algo::Decay::TopHad};
-  //hypotheses["H1"] = {Algo::Decay::Radiation_b, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
-  //hypotheses["H2"] = {Algo::Decay::Radiation_b, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
-  //hypotheses["H3"] = {Algo::Decay::Radiation_b, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
-  //hypotheses["H4"] = {Algo::Decay::Radiation_b, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
-  //hypotheses["H2"] = {Algo::Decay::WHad, Algo::Decay::Radiation_b};
+  map<string, vector<Algo::Decay::Decay> > hypotheses;
+  hypotheses["H0"] = {Algo::Decay::Decay::TopHad};
+  //hypotheses["H1"] = {Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
+  //hypotheses["H2"] = {Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
+  //hypotheses["H3"] = {Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
+  //hypotheses["H4"] = {Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
+  //hypotheses["H2"] = {Algo::Decay::Decay::WHad, Algo::Decay::Decay::Radiation_b};
   tester->test( hypotheses );
 
   TFile* fout = new TFile("test/Test.root", "RECREATE");
@@ -70,10 +70,10 @@ int main(){
 
   /*
   // assumptions
-  //tester->assume( Algo::Decay::TopHad  );
-  //tester->assume( Algo::Decay::WHad  );
-  tester->assume( Algo::Decay::TopLep   );
-  //tester->assume( Algo::Decay::Higgs );
+  //tester->assume( Algo::Decay::Decay::TopHad  );
+  //tester->assume( Algo::Decay::Decay::WHad  );
+  tester->assume( Algo::Decay::Decay::TopLep   );
+  //tester->assume( Algo::Decay::Decay::Higgs );
 
   // printout
   tester->print(cout);

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,59 @@
+import ROOT
+ROOT.gSystem.Load("libFWCoreFWLite")
+ROOT.gROOT.ProcessLine('AutoLibraryLoader::enable();')
+ROOT.gSystem.Load("libFWCoreFWLite")
+ROOT.gSystem.Load("libCintex")
+ROOT.gROOT.ProcessLine('ROOT::Cintex::Cintex::Enable();')
+ROOT.gSystem.Load("libTTHMEIntegratorStandalone")
+from ROOT import Algo
+from ROOT import TLorentzVector
+
+from ROOT.std import map
+tf = ROOT.TFile("out.root", "RECREATE")
+tf.cd()
+tt = ROOT.TTree("a", "a")
+
+j1 = TLorentzVector()
+j1.SetPtEtaPhiM(50., 0., ROOT.TMath.Pi()*2/3, 0.);
+
+j2 = TLorentzVector()
+j2.SetPtEtaPhiM( 30., 0.,  0., 0.);
+
+j3 = TLorentzVector()
+j3.SetPtEtaPhiM( 50., 0., -ROOT.TMath.Pi()/2, 0.);
+
+j4 = TLorentzVector()
+j4.SetPtEtaPhiM(100., 0., -ROOT.TMath.Pi()/4, 0.);
+
+j5 = TLorentzVector()
+j5.SetPtEtaPhiM(80., 0., -ROOT.TMath.Pi()/5, 0.);
+
+j6 = TLorentzVector()
+j6.SetPtEtaPhiM(120., 0., -ROOT.TMath.Pi()/6, 0.);
+
+lep = TLorentzVector()
+lep.SetPtEtaPhiM( 50., 1., ROOT.TMath.Pi()/3, 0.);
+
+met = TLorentzVector()
+met.SetPtEtaPhiM( 0., 0., 0., 0.);
+
+ht = Algo.HypoTester(tt)
+#ht = Algo.HypoTester()
+for j in [j1, j2, j3, j4, j5, j6]:
+    ht.push_back_object(j, 'j')
+ht.push_back_object(lep, 'l')
+ht.push_back_object(met, 'm')
+
+hmap = getattr(ROOT, "map<string,vector<Algo::Decay::Decay> >")()
+#ROOT.gROOT.ProcessLine("typedef std::map<std::string, std::vector<Algo::Decay> > HypoMap;")
+#hmap = ROOT.HypoMap()
+vec0 = getattr(ROOT, "vector<Algo::Decay::Decay>")()
+vec0.push_back(ROOT.Algo.Decay.TopHad)
+
+hmap[ROOT.std.string("h0")] = vec0
+
+print "Testing hypos"
+ht.test(hmap)
+
+tf.Write()
+print "All done"

--- a/test/toy.cpp
+++ b/test/toy.cpp
@@ -101,132 +101,132 @@ int main(int argc, char *argv[]){
 
   Algo::ToyGenerator* toyGenerator = new Algo::ToyGenerator(verbose, seed);
 
-  vector<Algo::Decay> decays;
+  vector<Algo::Decay::Decay> Decay::Decays;
 
   switch( gen_hypo ){
   case GEN_tH_wH:
-    decays.push_back( Algo::Decay::TopHad );
-    decays.push_back( Algo::Decay::Higgs ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );
+    Decay::Decays.push_back( Algo::Decay::Decay::Higgs ); 
     break;
   case GEN_tH_tL:
-    decays.push_back( Algo::Decay::TopHad );  
-    decays.push_back( Algo::Decay::TopLep );   
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );   
     break;
   case GEN_tH_tL_hH:
-    decays.push_back( Algo::Decay::TopHad );
-    decays.push_back( Algo::Decay::TopLep ); 
-    decays.push_back( Algo::Decay::Higgs );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::Higgs );
     break;
   case GEN_tL_tL_hH:
-    decays.push_back( Algo::Decay::TopLep );  
-    decays.push_back( Algo::Decay::TopLep );  
-    decays.push_back( Algo::Decay::Higgs );   
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Higgs );   
     break;
   case GEN_tH_tH_hH:
-    decays.push_back( Algo::Decay::TopHad );  
-    decays.push_back( Algo::Decay::TopHad );  
-    decays.push_back( Algo::Decay::Higgs );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Higgs );  
     break;
   case GEN_tH_bb:
-    decays.push_back( Algo::Decay::TopHad ); 
-    decays.push_back( Algo::Decay::Radiation_b );  
-    decays.push_back( Algo::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
     break;
   case GEN_udb_tL:
-    decays.push_back( Algo::Decay::Radiation_u );       
-    decays.push_back( Algo::Decay::Radiation_d );        
-    decays.push_back( Algo::Decay::Radiation_b ); 
-    decays.push_back( Algo::Decay::TopLep );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_u );       
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );        
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );  
     break;
   case GEN_tH_tL_bb:
-    decays.push_back( Algo::Decay::TopHad );  
-    decays.push_back( Algo::Decay::TopLep );        
-    decays.push_back( Algo::Decay::Radiation_b );     
-    decays.push_back( Algo::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );        
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );     
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
     break;
   case GEN_tH_tL_cc:
-    decays.push_back( Algo::Decay::TopHad );  
-    decays.push_back( Algo::Decay::TopLep );        
-    decays.push_back( Algo::Decay::Radiation_c );     
-    decays.push_back( Algo::Decay::Radiation_c );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );        
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_c );     
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_c );  
     break;
   case GEN_tH_tL_dd:
-    decays.push_back( Algo::Decay::TopHad );
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
     break;
   case GEN_tL_tL_bb:
-    decays.push_back( Algo::Decay::TopLep ); 
-    decays.push_back( Algo::Decay::TopLep );  
-    decays.push_back( Algo::Decay::Radiation_b );     
-    decays.push_back( Algo::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );     
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
     break;
   case GEN_tL_tL_dd:
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Radiation_d );
-    decays.push_back( Algo::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
     break;
   case GEN_tH_tH_bb:
-    decays.push_back( Algo::Decay::TopHad ); 
-    decays.push_back( Algo::Decay::TopHad ); 
-    decays.push_back( Algo::Decay::Radiation_b );  
-    decays.push_back( Algo::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad ); 
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );  
     break;
   case GEN_tH_tH_dd:
-    decays.push_back( Algo::Decay::TopHad );
-    decays.push_back( Algo::Decay::TopHad );
-    decays.push_back( Algo::Decay::Radiation_d );
-    decays.push_back( Algo::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHad );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
     break;
   case GEN_tL_ggggg:
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
     break;
   case GEN_lm_gggggg:
-    decays.push_back( Algo::Decay::Lepton );
-    decays.push_back( Algo::Decay::MET );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Lepton );
+    Decay::Decays.push_back( Algo::Decay::Decay::MET );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
     break;
   case GEN_lm_ggggbb:
-    decays.push_back( Algo::Decay::Lepton );
-    decays.push_back( Algo::Decay::MET );
-    decays.push_back( Algo::Decay::Radiation_b );
-    decays.push_back( Algo::Decay::Radiation_b );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
-    decays.push_back( Algo::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Lepton );
+    Decay::Decays.push_back( Algo::Decay::Decay::MET );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_g );
     break;
   case GEN_tHLost_tL_Hh_d:
-    decays.push_back( Algo::Decay::TopHadLost );
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Higgs );
-    decays.push_back( Algo::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHadLost );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Higgs );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
     break;
   case GEN_tHLost_tL_ddd:
-    decays.push_back( Algo::Decay::TopHadLost );
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Radiation_d );
-    decays.push_back( Algo::Decay::Radiation_d );
-    decays.push_back( Algo::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHadLost );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
     break;
   case GEN_tHLost_tL_bbd:
-    decays.push_back( Algo::Decay::TopHadLost );
-    decays.push_back( Algo::Decay::TopLep );
-    decays.push_back( Algo::Decay::Radiation_b );
-    decays.push_back( Algo::Decay::Radiation_b );
-    decays.push_back( Algo::Decay::Radiation_d );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopHadLost );
+    Decay::Decays.push_back( Algo::Decay::Decay::TopLep );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_b );
+    Decay::Decays.push_back( Algo::Decay::Decay::Radiation_d );
     break;
   default:
     break;
@@ -235,7 +235,7 @@ int main(int argc, char *argv[]){
   int itoy = 0;
   while( itoy < ntoys ){
     vector<Algo::Object> out = 
-      toyGenerator->generate( decays , smear, btag );
+      toyGenerator->generate( Decay::Decays , smear, btag );
 
     int count_j = 0;
     int count_l = 0;
@@ -308,9 +308,9 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = {Algo::Decay::TopHad, Algo::Decay::TopLep};
-      hypotheses["H1"] = {Algo::Decay::TopLep, Algo::Decay::Radiation_u, Algo::Decay::Radiation_d, Algo::Decay::Radiation_b};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_u, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_b};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -338,10 +338,10 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Higgs};
-      hypotheses["H1"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
-      hypotheses["H2"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_d, Algo::Decay::Radiation_d};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
+      hypotheses["H2"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -368,9 +368,9 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = {Algo::Decay::TopLep, Algo::Decay::TopLep, Algo::Decay::Higgs};
-      hypotheses["H1"] = {Algo::Decay::TopLep, Algo::Decay::TopLep, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = {Algo::Decay::Decay::TopLep, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopLep, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -394,9 +394,9 @@ int main(int argc, char *argv[]){
         }
       }
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = {Algo::Decay::TopHad, Algo::Decay::TopHad, Algo::Decay::Higgs};
-      hypotheses["H1"] = {Algo::Decay::TopHad, Algo::Decay::TopHad, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopHad, Algo::Decay::Decay::Higgs};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopHad, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -421,10 +421,10 @@ int main(int argc, char *argv[]){
 	}
       }
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      //hypotheses["H0"] = {Algo::Decay::TopHadLost, Algo::Decay::Higgs, Algo::Decay::Radiation_g};
-      hypotheses["H0"] = {Algo::Decay::TopHad, Algo::Decay::Higgs};
-      hypotheses["H1"] = {Algo::Decay::TopHad, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      //hypotheses["H0"] = {Algo::Decay::Decay::TopHadLost, Algo::Decay::Decay::Higgs, Algo::Decay::Decay::Radiation_g};
+      hypotheses["H0"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::Higgs};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -451,10 +451,10 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
       
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = { Algo::Decay::TopLep };
-      hypotheses["H1"] = { Algo::Decay::Radiation_g, Algo::Decay::Radiation_g,Algo::Decay::Radiation_g,
-			   Algo::Decay::Radiation_g, Algo::Decay::Radiation_g,Algo::Decay::Radiation_g};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = { Algo::Decay::Decay::TopLep };
+      hypotheses["H1"] = { Algo::Decay::Decay::Radiation_g, Algo::Decay::Decay::Radiation_g,Algo::Decay::Decay::Radiation_g,
+			   Algo::Decay::Decay::Radiation_g, Algo::Decay::Decay::Radiation_g,Algo::Decay::Decay::Radiation_g};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -483,17 +483,17 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
       // lepton + jets
-      hypotheses["Ha1"]  = { Algo::Decay::Radiation_d, Algo::Decay::Radiation_d,Algo::Decay::Radiation_d,
-			     Algo::Decay::Radiation_d, Algo::Decay::Radiation_d,Algo::Decay::Radiation_d}; // 0
-      hypotheses["Ha2"]  = { Algo::Decay::Radiation_b, Algo::Decay::Radiation_b,Algo::Decay::Radiation_d,
-                             Algo::Decay::Radiation_d, Algo::Decay::Radiation_d,Algo::Decay::Radiation_d}; // 1
-      hypotheses["Hb0"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_g, Algo::Decay::Radiation_g}; // 2
-      hypotheses["Hb1"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_d, Algo::Decay::Radiation_d}; // 3
-      hypotheses["Hb2"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_c, Algo::Decay::Radiation_c}; // 4
-      hypotheses["Hb3"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b}; // 5
-      hypotheses["Hs"]  = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Higgs}; // 6
+      hypotheses["Ha1"]  = { Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d,Algo::Decay::Decay::Radiation_d,
+			     Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d,Algo::Decay::Decay::Radiation_d}; // 0
+      hypotheses["Ha2"]  = { Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b,Algo::Decay::Decay::Radiation_d,
+                             Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d,Algo::Decay::Decay::Radiation_d}; // 1
+      hypotheses["Hb0"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_g, Algo::Decay::Decay::Radiation_g}; // 2
+      hypotheses["Hb1"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d}; // 3
+      hypotheses["Hb2"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_c, Algo::Decay::Decay::Radiation_c}; // 4
+      hypotheses["Hb3"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b}; // 5
+      hypotheses["Hs"]  = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs}; // 6
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -521,9 +521,9 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["H0"] = {Algo::Decay::TopHadLost, Algo::Decay::TopLep, Algo::Decay::Higgs, Algo::Decay::Radiation_d};
-      hypotheses["H1"] = {Algo::Decay::TopHad, Algo::Decay::TopLep, Algo::Decay::Higgs};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["H0"] = {Algo::Decay::Decay::TopHadLost, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs, Algo::Decay::Decay::Radiation_d};
+      hypotheses["H1"] = {Algo::Decay::Decay::TopHad, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;
@@ -551,13 +551,13 @@ int main(int argc, char *argv[]){
       }
       tester->push_back_object( invisible  , 'm');
 
-      map<string, vector<Algo::Decay> > hypotheses;
-      hypotheses["Hs0"] = {Algo::Decay::TopHadLost, Algo::Decay::TopLep, Algo::Decay::Higgs,       Algo::Decay::Radiation_d};
-      hypotheses["Hs1"] = {Algo::Decay::TopHad,     Algo::Decay::TopLep, Algo::Decay::Higgs};
-      hypotheses["Hb0"] = {Algo::Decay::TopHadLost, Algo::Decay::TopLep, Algo::Decay::Radiation_d, Algo::Decay::Radiation_d, Algo::Decay::Radiation_d};
-      hypotheses["Hb1"] = {Algo::Decay::TopHad,     Algo::Decay::TopLep, Algo::Decay::Radiation_d, Algo::Decay::Radiation_d};
-      hypotheses["Hb2"] = {Algo::Decay::TopHadLost, Algo::Decay::TopLep, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b, Algo::Decay::Radiation_d};
-      hypotheses["Hb3"] = {Algo::Decay::TopHad,     Algo::Decay::TopLep, Algo::Decay::Radiation_b, Algo::Decay::Radiation_b};
+      map<string, vector<Algo::Decay::Decay> > hypotheses;
+      hypotheses["Hs0"] = {Algo::Decay::Decay::TopHadLost, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs,       Algo::Decay::Decay::Radiation_d};
+      hypotheses["Hs1"] = {Algo::Decay::Decay::TopHad,     Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Higgs};
+      hypotheses["Hb0"] = {Algo::Decay::Decay::TopHadLost, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d};
+      hypotheses["Hb1"] = {Algo::Decay::Decay::TopHad,     Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_d, Algo::Decay::Decay::Radiation_d};
+      hypotheses["Hb2"] = {Algo::Decay::Decay::TopHadLost, Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_d};
+      hypotheses["Hb3"] = {Algo::Decay::Decay::TopHad,     Algo::Decay::Decay::TopLep, Algo::Decay::Decay::Radiation_b, Algo::Decay::Decay::Radiation_b};
       if(verbose>0) tester->print(cout);
       tester->test( hypotheses );
       if(tester->get_status()>0) cerr << "ERROR STATUS for tester" << endl;


### PR DESCRIPTION
Created Python wrapper of new MEM integrator using genreflex. Works via CMSSW scram b.
Some C++11-specific idioms had to be removed from the header files, therefore it would be good to merge to the master and base further development off that. I didn't update the Makefile as I could not make it work within the standard CMSSW framework.

To test
~~~
cd CMSSW_7_2_2_patch2/src/TTH
git clone https://github.com/jpata/Code.git MEIntegratorStandalone
cd MEIntegratorStandalone
git checkout pythonwrapper
scram b
python test/test.py
~~~

@gkasieczka