### PR TITLE
added jet likelihood calculator (blr, qglr)

### DIFF
--- a/interface/JetLikelihood.h
+++ b/interface/JetLikelihood.h
@@ -1,0 +1,52 @@
+#ifndef JETLIKELIHOOD_H
+#define JETLIKELIHOOD_H
+
+#include "interface/Utils.h"
+#include <map>
+
+namespace MEM {
+
+    //possible ways a jet can be interepreted
+    namespace JetInterpretation {
+        enum JetInterpretation {
+            l,
+            c,
+            g,
+            b
+        };
+    }
+
+    //collects probabilities of a jet arising from different interpretations
+    class JetProbability {
+        public:
+            std::map<JetInterpretation::JetInterpretation, double> probas;
+            void setProbability(JetInterpretation::JetInterpretation h, double p) {
+                probas[h] = p;
+            }
+    };
+
+
+    class JetLikelihood {
+    public:
+
+        // calculates a probability for a sample of jets being divided between Hypo1 and Hypo2
+        // with the assumption that nhypo1 of the jets are from Hypo1
+        // e.g. Hypo1 = b, Hypo2 = l, nhypo1=4 calculates the probability that 4 of the jets were b quarks.
+        double calcProbability(
+            MEM::JetInterpretation::JetInterpretation hypo1,
+            MEM::JetInterpretation::JetInterpretation hypo2,
+            unsigned int nhypo1,
+            std::vector<unsigned int>& outBestPerm
+        );
+        void push_back_object( const JetProbability& jp ) {
+            jets.push_back(jp);
+        }
+        void next_event() {
+            jets.clear();
+        }
+
+        std::vector<JetProbability> jets;
+    };
+}
+
+#endif

--- a/src/JetLikelihood.cpp
+++ b/src/JetLikelihood.cpp
@@ -1,0 +1,56 @@
+#include "interface/JetLikelihood.h"
+#include <iostream>
+
+using namespace std;
+using namespace MEM;
+
+double JetLikelihood::calcProbability(
+    MEM::JetInterpretation::JetInterpretation hypo1,
+    MEM::JetInterpretation::JetInterpretation hypo2,
+    unsigned int nhypo1,
+    vector<unsigned int>& outBestPerm
+    ) {
+    vector<unsigned int> perm_index_copy;
+
+    //cout << "calcProbability njets=" << jets.size() << " nhypo1=" << nhypo1 << endl;
+    for (unsigned int i=0; i<jets.size(); i++) {
+        perm_index_copy.push_back(i);
+    }
+
+    int nperms = 0;
+    double P = 0.0;
+    double maxCombP = 0;
+    vector<unsigned int> bestPerm;
+
+    //In case less jets specified than in hypo, truncate
+    if (jets.size() < nhypo1) {
+        //cout << "truncating " << nhypo1 << " to " << jets.size() << endl;
+        nhypo1 = jets.size();
+    }
+
+    do {
+        unsigned int ip = 0;
+        double combP = 1.0;
+        for (auto& p : perm_index_copy) {
+            const auto& jet = jets.at(p);
+            double _p = jet.probas.at(ip < nhypo1 ? hypo1 : hypo2);
+            combP *= _p;
+            ip += 1;
+        }
+        if (combP > maxCombP) {
+            maxCombP = combP;
+            bestPerm = perm_index_copy;
+        }
+        P += combP;
+
+        nperms += 1;
+    } while( next_combination(
+        perm_index_copy.begin(),
+        perm_index_copy.begin() + nhypo1,
+        perm_index_copy.end(),
+        std::less<int>()
+        )
+    );
+    outBestPerm = bestPerm;
+    return P;
+}

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,5 +1,6 @@
 #include "TTH/MEIntegratorStandalone/interface/Integrand.h"
 #include "TTH/MEIntegratorStandalone/interface/BTagRandomizer.h"
+#include "TTH/MEIntegratorStandalone/interface/JetLikelihood.h"
 
 //template class map<string, vector<Algo::Decay::Decay> >;
 //template class vector<Algo::Decay::Decay>;

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -15,11 +15,13 @@
 	<enum name="MEM::DebugVerbosity"/>
 	<enum name="MEM::DistributionType::DistributionType"/>
 	
+
 	<class name="MEM::MEMOutput"/>
 	<class name="MEM::MEMConfig"/>
 	
 	<class name="std::vector<MEM::PSVar::PSVar>"/>
 	<class name="std::vector<MEM::Permutations::Permutations>"/>
+	<class name="std::vector<unsigned int>"/>
 	
 	<class name="std::pair<MEM::TFType::TFType,int>"/>
 	<class name="std::pair<MEM::DistributionType::DistributionType,TH3D>"/>
@@ -29,5 +31,9 @@
 	<class name="MEM::BTagRandomizer"/>
 	<class name="MEM::BTagRandomizerOutput"/>
 	<class name="MEM::JetCategory"/>
+
+	<enum name="MEM::JetInterpretation::JetInterpretation"/>
+	<class name="MEM::JetProbability"/>
+	<class name="MEM::JetLikelihood"/>
 
 </lcgdict>

--- a/test/jetlikelihood.py
+++ b/test/jetlikelihood.py
@@ -1,0 +1,26 @@
+import ROOT
+ROOT.gSystem.Load("libTTHMEIntegratorStandalone")
+from ROOT import MEM
+jlh = MEM.JetLikelihood()
+
+Cvectoruint = getattr(ROOT, "std::vector<unsigned int>")
+
+for i in range(2):
+    jp1 = ROOT.MEM.JetProbability()
+    jp1.setProbability(MEM.JetInterpretation.l, 0.2)
+    jp1.setProbability(MEM.JetInterpretation.b, 0.8)
+
+    jp2 = ROOT.MEM.JetProbability()
+    jp2.setProbability(MEM.JetInterpretation.l, 0.2)
+    jp2.setProbability(MEM.JetInterpretation.b, 0.8)
+
+    jlh.push_back_object(jp1)
+    jlh.push_back_object(jp2)
+
+    bperm = Cvectoruint()
+
+    print jlh.calcProbability(MEM.JetInterpretation.b, MEM.JetInterpretation.l, 0, bperm)
+    print jlh.calcProbability(MEM.JetInterpretation.b, MEM.JetInterpretation.l, 1, bperm)
+    print jlh.calcProbability(MEM.JetInterpretation.b, MEM.JetInterpretation.l, 2, bperm)
+    print bperm.size(), [bperm.at(i) for i in range(bperm.size())]
+    jlh.next_event()


### PR DESCRIPTION
Simple calculator combined likelihood for jets. Can be used to evaluate e.g. b vs. light or q. vs. g hypotheses. Already included in the tthbb13 code, reproduces the existing blr except for nJet<nTagHypo.
