### PR TITLE
pointer-based TF

### DIFF
--- a/bin/integrator.cpp
+++ b/bin/integrator.cpp
@@ -42,18 +42,18 @@ int main(){
   cfg.transfer_function_method = TFMethod::External;
 
   //Transfer functions for jet reconstruction efficiency
-  cfg.set_tf_global(TFType::bLost, 0, *getTransferFunction(tffile, "beff", 0.0));
-  cfg.set_tf_global(TFType::bLost, 1, *getTransferFunction(tffile, "beff", 2.0));
-  cfg.set_tf_global(TFType::qLost, 0, *getTransferFunction(tffile, "leff", 0.0));
-  cfg.set_tf_global(TFType::qLost, 1, *getTransferFunction(tffile, "leff", 2.0));
+  cfg.set_tf_global(TFType::bLost, 0, getTransferFunction(tffile, "beff", 0.0));
+  cfg.set_tf_global(TFType::bLost, 1, getTransferFunction(tffile, "beff", 2.0));
+  cfg.set_tf_global(TFType::qLost, 0, getTransferFunction(tffile, "leff", 0.0));
+  cfg.set_tf_global(TFType::qLost, 1, getTransferFunction(tffile, "leff", 2.0));
 
   //Create the mem integrator, once per job
   Integrand* integrand = new Integrand( 
     DebugVerbosity::output
-    //|DebugVerbosity::init
-    //|DebugVerbosity::input
-    //|DebugVerbosity::init_more
-    //|DebugVerbosity::integration				        
+    |DebugVerbosity::init
+    |DebugVerbosity::input
+    |DebugVerbosity::init_more
+    |DebugVerbosity::integration				        
     ,cfg
   );
 

--- a/interface/Integrand.h
+++ b/interface/Integrand.h
@@ -253,7 +253,7 @@ namespace MEM {
     std::size_t prefit_step;
     
     //Stores the global cumulative transfer functions for jet reconstruction efficiency
-    const std::map<std::pair<TFType::TFType, int>, TF1> tf_map;
+    const std::map<std::pair<TFType::TFType, int>, TF1*> tf_map;
     
     //the PDF-s for the b-tagger discriminants
     std::map<DistributionType::DistributionType, TH3D> btag_pdfs;

--- a/interface/Parameters.h
+++ b/interface/Parameters.h
@@ -372,7 +372,7 @@ namespace MEM {
     void defaultCfg(float nCallsMultiplier=1.0);
     void setNCalls(FinalState::FinalState, Hypothesis::Hypothesis, Assumption::Assumption, int);
     int getNCalls(FinalState::FinalState, Hypothesis::Hypothesis, Assumption::Assumption);
-    void set_tf_global(TFType::TFType type, int etabin, TF1 tf);
+    void set_tf_global(TFType::TFType type, int etabin, TF1 *tf);
     void add_distribution_global(DistributionType::DistributionType type, TH3D tf);
 
     // optionally this can be called instead of the built-in array
@@ -440,7 +440,7 @@ namespace MEM {
     // do a pre-fit to filter permutations
     int do_prefit;
 
-    std::map<std::pair<TFType::TFType, int>, TF1> tf_map;
+    std::map<std::pair<TFType::TFType, int>, TF1*> tf_map;
     
     std::map<DistributionType::DistributionType, TH3D> btag_pdfs;
   };

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -580,7 +580,14 @@ std::size_t MEM::Object::getNumTransferFunctions() const {
 void MEM::Object::print(ostream& os) const {
   os << "\tType: " << static_cast<int>(t) << ", p=(Pt, Eta, Phi, M)=("
      << p.Pt() << ", " << p.Eta() << ", " << p.Phi() << ", " << p.M()
-     << ")" << endl;
+     << ")";
+  for (auto& kv : obs) {
+    os << " " << kv.first << "->" << kv.second;
+  }
+  for (auto& kv : transfer_funcs) {
+    os << " tf " << kv.first << "->" << ((TF1*)kv.second);
+  }
+    os << endl;
 }
 
 MEM::MEMConfig::MEMConfig(int nmc, 
@@ -757,7 +764,7 @@ int MEM::getEtaBin(double eta) {
 }
 */
 
-void MEM::MEMConfig::set_tf_global(TFType::TFType type, int etabin, TF1 tf) {
+void MEM::MEMConfig::set_tf_global(TFType::TFType type, int etabin, TF1 *tf) {
     tf_map[std::make_pair(type, etabin)] = tf;
 }
 


### PR DESCRIPTION
Transfer functions need to be pointer based to make the C++ interface work without surprises.